### PR TITLE
Type hints to Qubit where applicable and optimizing imports.

### DIFF
--- a/dc_qiskit_algorithms/FlipFlopQuantumRam.py
+++ b/dc_qiskit_algorithms/FlipFlopQuantumRam.py
@@ -48,11 +48,11 @@ add_vector
 """
 
 import math
-from typing import Tuple, List, Union
+from typing import List, Union
 
 from bitarray import bitarray
 from qiskit import QuantumRegister, QuantumCircuit
-from qiskit.circuit.register import Register
+from qiskit.circuit import Qubit
 from qiskit.extensions.standard.x import x
 
 from .UniformRotation import cnry
@@ -96,7 +96,7 @@ class FFQramEntry(object):
         return self.get_bits().length()
 
     def add_to_circuit(self, qc, bus, register):
-        # type: (FFQramEntry, QuantumCircuit, Union[QuantumRegister, list], Tuple[QuantumRegister, int]) -> QuantumCircuit
+        # type: (FFQramEntry, QuantumCircuit, Union[QuantumRegister, list], Qubit) -> QuantumCircuit
         """
         This method adds the gates to encode this entry into the circuit
         :param qc: quantum circuit to apply the entry to
@@ -107,9 +107,9 @@ class FFQramEntry(object):
         theta = math.asin(self.probability_amplitude)
         if theta == 0:
             return qc
-        bus_register = []  # type: List[Tuple[QuantumRegister, int]]
+        bus_register = []  # type: List[Qubit]
         if isinstance(bus, QuantumRegister):
-            bus_register = [(bus, i) for i in range(bus.size)]
+            bus_register = list(bus)
         else:
             bus_register = bus
 
@@ -158,7 +158,7 @@ class FFQramDb(List[FFQramEntry]):
         return max([e.bus_size() for e in self])
 
     def add_to_circuit(self, qc, bus, register):
-        # type: (FFQramDb, QuantumCircuit, Union[QuantumRegister, list], Tuple[Union[QuantumRegister, Register], int]) -> None
+        # type: (FFQramDb, QuantumCircuit, Union[QuantumRegister, List[Qubit]], Qubit) -> None
         """
         Add the DB to the circuit.
 
@@ -167,11 +167,8 @@ class FFQramDb(List[FFQramEntry]):
         :param register: the target register for the amplitudes
         :return: the circuit after DB being applied
         """
-        if not isinstance(register[0], QuantumRegister):
-            raise Exception("Register must be a QuantumRegister!")  # type: Tuple[QuantumRegister, int]
-        reg = (register[0], register[1])
         for entry in self:
-            entry.add_to_circuit(qc, bus, reg)
+            entry.add_to_circuit(qc, bus, register)
 
     def add_entry(self, pa, data, label):
         # type: (FFQramDb, float, bytes, bytes) -> None

--- a/dc_qiskit_algorithms/Qft.py
+++ b/dc_qiskit_algorithms/Qft.py
@@ -48,9 +48,8 @@ qft_dg
 import math
 from typing import Tuple, List, Union
 
-import qiskit.extensions.standard as standard
 from qiskit import QuantumRegister, QuantumCircuit
-from qiskit.circuit import Gate, Instruction
+from qiskit.circuit import Gate, Instruction, Qubit, Clbit
 from qiskit.extensions import HGate, Cu1Gate
 
 
@@ -73,7 +72,7 @@ class QuantumFourierTransformGate(Gate):
         super().__init__("qft", num_qubits=num_qubits, params=[])
 
     def _define(self):
-        rule = []  # type: List[Tuple[Gate, list, list]]
+        rule = []  # type: List[Tuple[Gate, List[Qubit], List[Clbit]]]
         qreg = QuantumRegister(self.num_qubits, "qreg")
         q_list = list(qreg)
 
@@ -93,7 +92,7 @@ class QuantumFourierTransformGate(Gate):
 
 
 def qft(self, q):
-    # type: (QuantumCircuit, Union[List[Tuple[QuantumRegister, int]], QuantumRegister]) -> Instruction
+    # type: (QuantumCircuit, Union[List[Qubit], QuantumRegister]) -> Instruction
     """
     Applies the Quantum Fourier Transform to q
     :param self: the circuit to which the qft is applied
@@ -104,7 +103,7 @@ def qft(self, q):
 
 
 def qft_dg(self, q):
-    # type: (QuantumCircuit, Union[List[Tuple[QuantumRegister, int]], QuantumRegister]) -> Instruction
+    # type: (QuantumCircuit, Union[List[Qubit], QuantumRegister]) -> Instruction
     """
         Applies the inverse Quantum Fourier Transform to q
         :param self: the circuit to which the qft_dag is applied

--- a/dc_qiskit_algorithms/UniformRotation.py
+++ b/dc_qiskit_algorithms/UniformRotation.py
@@ -273,7 +273,7 @@ def uni_rot(self, rotation_gate, alpha, control_qubits, tgt):
 
 
 def uni_rot_dg(self, rotation_gate, alpha, control_qubits, tgt):
-    # type: (QuantumCircuit, Callable[[float], Gate], Union[List[float], sparse.dok_matrix], Union[List[Tuple[QuantumRegister, int]],QuantumRegister], Union[Tuple[QuantumRegister, int], QuantumRegister]) -> Instruction
+    # type: (QuantumCircuit, Callable[[float], Gate], Union[List[float], sparse.dok_matrix], Union[List[Qubit],QuantumRegister], Union[Qubit, QuantumRegister]) -> Instruction
     """
     Apply the dagger (inverse) of a generic uniform rotation with rotation gate.
     :param self: either a composite gate or a circuit
@@ -287,7 +287,7 @@ def uni_rot_dg(self, rotation_gate, alpha, control_qubits, tgt):
 
 
 def unirz(self, alpha, control_qubits, tgt):
-    # type: (QuantumCircuit, Union[List[float], sparse.dok_matrix], Union[List[Tuple[QuantumRegister, int]],QuantumRegister], Union[Tuple[QuantumRegister, int], QuantumRegister]) -> Instruction
+    # type: (QuantumCircuit, Union[List[float], sparse.dok_matrix], Union[List[Qubit],QuantumRegister], Union[Qubit, QuantumRegister]) -> Instruction
     """
     Apply a uniform rotation around z.
     :param self: either a composite gate or a circuit
@@ -301,7 +301,7 @@ def unirz(self, alpha, control_qubits, tgt):
 
 
 def unirz_dg(self, alpha, control_qubits, tgt):
-    # type: (QuantumCircuit, Union[List[float], sparse.dok_matrix], Union[List[Tuple[QuantumRegister, int]],QuantumRegister], Union[Tuple[QuantumRegister, int], QuantumRegister]) -> Instruction
+    # type: (QuantumCircuit, Union[List[float], sparse.dok_matrix], Union[List[Qubit],QuantumRegister], Union[Qubit, QuantumRegister]) -> Instruction
     """
     Apply dagger (inverse) of a uniform rotation around z.
     :param self: either a composite gate or a circuit
@@ -314,7 +314,7 @@ def unirz_dg(self, alpha, control_qubits, tgt):
 
 
 def uniry(self, alpha, control_qubits, tgt):
-    # type: (QuantumCircuit, Union[List[float], sparse.dok_matrix], Union[List[Tuple[QuantumRegister, int]],QuantumRegister], Union[Tuple[QuantumRegister, int], QuantumRegister]) -> Instruction
+    # type: (QuantumCircuit, Union[List[float], sparse.dok_matrix], Union[List[Qubit],QuantumRegister], Union[Qubit, QuantumRegister]) -> Instruction
     """
     Apply a uniform rotation around y.
     :param self: either a composite gate or a circuit
@@ -328,7 +328,7 @@ def uniry(self, alpha, control_qubits, tgt):
 
 
 def uniry_dg(self, alpha, control_qubits, tgt):
-    # type: (QuantumCircuit, Union[List[float], sparse.dok_matrix], Union[List[Tuple[QuantumRegister, int]],QuantumRegister], Union[Tuple[QuantumRegister, int], QuantumRegister]) -> Instruction
+    # type: (QuantumCircuit, Union[List[float], sparse.dok_matrix], Union[List[Qubit],QuantumRegister], Union[Qubit, QuantumRegister]) -> Instruction
     """
     Apply the dagger (inverse) of a uniform rotation around y.
     :param self: either a composite gate or a circuit
@@ -341,7 +341,7 @@ def uniry_dg(self, alpha, control_qubits, tgt):
 
 
 def cnry(self, theta, control_qubits, tgt):
-    # type: (QuantumCircuit, float, Union[List[Tuple[QuantumRegister, int]],QuantumRegister], Union[Tuple[QuantumRegister, int], QuantumRegister]) -> Instruction
+    # type: (QuantumCircuit, float, Union[List[Qubit],QuantumRegister], Union[Qubit, QuantumRegister]) -> Instruction
     """
     Apply a multiple controlled y rotation on the target qubit.
     :param self: either a composite gate or a circuit
@@ -357,7 +357,7 @@ def cnry(self, theta, control_qubits, tgt):
 
 
 def cnry_dg(self, theta, control_qubits, tgt):
-    # type: (QuantumCircuit, float, Union[List[Tuple[QuantumRegister, int]],QuantumRegister], Union[Tuple[QuantumRegister, int], QuantumRegister]) -> Instruction
+    # type: (QuantumCircuit, float, Union[List[Qubit],QuantumRegister], Union[Qubit, QuantumRegister]) -> Instruction
     """
     Apply the dagger (inverse) of a multiple controlled y rotation on the target qubit.
     :param self: either a composite gate or a circuit
@@ -416,7 +416,7 @@ def ccx_uni_rot(self, conditional_case, control_qubits, tgt):
 
 
 def ccx_uni_rot_dg(self, conditional_case, control_qubits, tgt):
-    # type: (QuantumCircuit, int, Union[List[Tuple[QuantumRegister, int]],QuantumRegister], Union[Tuple[QuantumRegister, int], QuantumRegister]) -> Instruction
+    # type: (QuantumCircuit, int, Union[List[Qubit],QuantumRegister], Union[Qubit, QuantumRegister]) -> Instruction
     """
     Apply the dagger (inverse) a multi-controlled X gate depending on conditional binary representation
     :param self: either a composite gate or a circuit


### PR DESCRIPTION
The new qiskit doesn't use tuples of `QuantumRegister` and `int` anymore but a new class the `Qubit`. 

This changes the rest that i missed the first time.