### PR TITLE
Can't be serialized as lambda. This is a fix.

### DIFF
--- a/dc_qiskit_algorithms/MöttönenStatePreparation.py
+++ b/dc_qiskit_algorithms/MöttönenStatePreparation.py
@@ -171,13 +171,17 @@ class MöttönenStatePreparationGate(Gate):
         :param qubits: qubits to which the scheme are applied
         :return: None
         """
+
+        def rotation_gate(theta):
+            return RYGate(-theta)
+
         rule = []  # type: List[Tuple[Gate, List[Qubit], List[Clbit]]]
         num_qubits = int(math.log2(a.shape[0]))
         for k in range(1, num_qubits + 1):
             alpha_y_k = get_alpha_y(a, num_qubits, k)  # type: sparse.dok_matrix
             control = qubits[k:]
             target = qubits[k - 1]
-            rule.append((UniformRotationGate(gate=lambda theta: RYGate(-theta), alpha=alpha_y_k), control + [target], []))
+            rule.append((UniformRotationGate(gate=rotation_gate, alpha=alpha_y_k), control + [target], []))
 
         return rule
 
@@ -190,6 +194,10 @@ class MöttönenStatePreparationGate(Gate):
         :param qubits: qubits to which the scheme are applied
         :return: None
         """
+
+        def rotation_gate(theta):
+            return RZGate(-theta)
+
         rule = []  # type: List[Tuple[Gate, List[Qubit], List[Clbit]]]
         num_qubits = int(math.log2(omega.shape[0]))
         for k in range(1, num_qubits + 1):
@@ -197,7 +205,7 @@ class MöttönenStatePreparationGate(Gate):
             control = qubits[k:]
             target = qubits[k - 1]
             # if len(alpha_z_k) != 0:
-            rule.append((UniformRotationGate(gate=lambda theta: RZGate(-theta), alpha=alpha_z_k), control + [target], []))
+            rule.append((UniformRotationGate(gate=rotation_gate, alpha=alpha_z_k), control + [target], []))
 
         return rule
 

--- a/dc_qiskit_algorithms/UniformRotation.py
+++ b/dc_qiskit_algorithms/UniformRotation.py
@@ -296,8 +296,10 @@ def unirz(self, alpha, control_qubits, tgt):
     :param tgt: target
     :return: applied composite gate or circuit
     """
+    def rotation_gate(theta):
+        return RZGate(theta)
 
-    return uni_rot(self, lambda theta: RZGate(theta), alpha, control_qubits, tgt)
+    return uni_rot(self, rotation_gate, alpha, control_qubits, tgt)
 
 
 def unirz_dg(self, alpha, control_qubits, tgt):
@@ -323,8 +325,10 @@ def uniry(self, alpha, control_qubits, tgt):
     :param tgt: target
     :return: applied composite gate or circuit
     """
+    def rotation_gate(theta):
+        return RYGate(theta)
 
-    return uni_rot(self, lambda theta: RYGate(theta), alpha, control_qubits, tgt)
+    return uni_rot(self, rotation_gate, alpha, control_qubits, tgt)
 
 
 def uniry_dg(self, alpha, control_qubits, tgt):


### PR DESCRIPTION
For the dc_qiskt_qml project we had the following problem:

```
AttributeError: Can't pickle local object 'uniry.<locals>.<lambda>'
```

Of course a lambda is not serializable. This fix should hopefully do it.