### PR TITLE
Fix the qiskit version and bump up the version.

### DIFF
--- a/dc_qiskit_algorithms/_version.py
+++ b/dc_qiskit_algorithms/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.0.8'
+__version__ = '0.0.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools
-qiskit
+qiskit<0.20.0
 numpy
 scipy
 bitstring


### PR DESCRIPTION
After qiskit was updated to 0.20.0 the way the definitions of gates are done slightly changed. First I will fix the versions to be applicable to qiskit<0.20.0. Then for release I'll tag (wow for the first time ever...) it.