### PR TITLE
Bugfix/bytes bit pattern ffqram

### DIFF
--- a/dc_qiskit_algorithms/FlipFlopQuantumRam.py
+++ b/dc_qiskit_algorithms/FlipFlopQuantumRam.py
@@ -50,7 +50,7 @@ add_vector
 import math
 from typing import List, Union
 
-from bitarray import bitarray
+from bitstring import BitArray
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit import Qubit
 
@@ -70,8 +70,8 @@ class FFQramEntry(object):
         self.data = bytes()  # type: bytes
         self.label = bytes()  # type: bytes
 
-    def get_bits(self):
-        # type: (FFQramEntry) -> bitarray
+    def get_bits(self, bin_length=None):
+        # type: (FFQramEntry) -> str
         """
         Get the binary bit representation of data and label
         for state basis identification
@@ -79,10 +79,9 @@ class FFQramEntry(object):
         :return: a bit array
         """
         b = self.data + self.label
-        ba = bitarray()
-        ba.frombytes(b)
-        ba = bitarray(ba.to01().lstrip('0'))
-        ba.reverse()
+        ba = BitArray(b)
+        ba = ba.bin.lstrip('0')
+        ba = ba.zfill(bin_length) if bin_length is not None else ba
         return ba
 
     def bus_size(self):
@@ -92,7 +91,7 @@ class FFQramEntry(object):
 
         :return: the length
         """
-        return self.get_bits().length()
+        return len(self.get_bits(1))
 
     def add_to_circuit(self, qc, bus, register):
         # type: (FFQramEntry, QuantumCircuit, Union[QuantumRegister, list], Qubit) -> QuantumCircuit
@@ -116,18 +115,20 @@ class FFQramEntry(object):
         for i in range(len(bus_register) - ba.length()):
             ba.append(False)
 
-        for i, b in enumerate(ba):
-            if not b: qc.x(bus_register[i])
+        for i, b in enumerate(reversed(ba)):
+            if b == "0":
+                qc.x(bus_register[i])
 
         cnry(qc, theta, bus_register, register)
 
-        for i, b in enumerate(ba):
-            if not b: qc.x(bus_register[i])
+        for i, b in enumerate(reversed(ba)):
+            if b == "0":
+                qc.x(bus_register[i])
 
         return qc
 
     def __str__(self):
-        return "FFQramEntry(%.8f, %s)" % (self.probability_amplitude, self.get_bits().to01())
+        return "FFQramEntry(%.8f, %s)" % (self.probability_amplitude, self.get_bits().bin)
 
     @staticmethod
     def _count_set_bits(b):
@@ -137,9 +138,7 @@ class FFQramEntry(object):
         :param b: the data
         :return: the count
         """
-        ba = bitarray()
-        ba.frombytes(b)
-        return ba.count()
+        raise DeprecationWarning("This method is as it stands not functional... there is no way to reconcile this.")
 
 
 class FFQramDb(List[FFQramEntry]):
@@ -193,13 +192,7 @@ class FFQramDb(List[FFQramEntry]):
         :param data: the integer value of the data
         :param label: the integer value of the label
         """
-        data_bits = [d == '1' for d in "{0:b}".format(data)]
-        label_bits = [d == '1' for d in "{0:b}".format(label)]
-        data_bits.reverse()
-        label_bits.reverse()
-        data_bytes = bitarray(data_bits, endian='little').tobytes()
-        label_bytes = bitarray(label_bits, endian='little').tobytes()
-        self.add_entry(pa, data_bytes, label_bytes)
+        raise DeprecationWarning("This method is as it stands not functional... there is no way to reconcile this.")
 
 
 def add_vector(db, vec):

--- a/dc_qiskit_algorithms/FlipFlopQuantumRam.py
+++ b/dc_qiskit_algorithms/FlipFlopQuantumRam.py
@@ -211,10 +211,4 @@ def add_vector(db, vec):
     for i, v in enumerate(unit_vector):
         if abs(v) > 1e-6:
             label_as_bytes = (i).to_bytes(number_of_bytes, byteorder='big')
-            label_check = int.from_bytes(label_as_bytes, byteorder='big')
-
-            from bitstring import BitArray
-            ba = BitArray(label_as_bytes)
-
             db.add_entry(v, b'', label_as_bytes)
-

--- a/dc_qiskit_algorithms/FlipFlopQuantumRam.py
+++ b/dc_qiskit_algorithms/FlipFlopQuantumRam.py
@@ -205,5 +205,16 @@ def add_vector(db, vec):
     vector = np.asarray(vec)
     l2_norm = np.linalg.norm(vector)
     unit_vector = vector / l2_norm
+
+    number_of_bytes = int(np.ceil(np.log2(len(vector))) // 8 + 1)
+
     for i, v in enumerate(unit_vector):
-        db.add_entry_int(v, 0, i)
+        if abs(v) > 1e-6:
+            label_as_bytes = (i).to_bytes(number_of_bytes, byteorder='big')
+            label_check = int.from_bytes(label_as_bytes, byteorder='big')
+
+            from bitstring import BitArray
+            ba = BitArray(label_as_bytes)
+
+            db.add_entry(v, b'', label_as_bytes)
+

--- a/dc_qiskit_algorithms/FlipFlopQuantumRam.py
+++ b/dc_qiskit_algorithms/FlipFlopQuantumRam.py
@@ -111,9 +111,7 @@ class FFQramEntry(object):
         else:
             bus_register = bus
 
-        ba = self.get_bits()
-        for i in range(len(bus_register) - ba.length()):
-            ba.append(False)
+        ba = self.get_bits(len(bus_register))
 
         for i, b in enumerate(reversed(ba)):
             if b == "0":

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,4 +4,3 @@ nbsphinx
 pygments-github-lexers
 pybind11
 qiskit
-bitarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ qiskit>=0.20.0
 numpy
 scipy
 bitstring
-bitarray
 scikit_learn
 ddt
 sympy

--- a/tests/test_FlipFlopQuantumRam.py
+++ b/tests/test_FlipFlopQuantumRam.py
@@ -108,9 +108,24 @@ class FlipFlopQuantumRamnStatePrepTests(unittest.TestCase):
         {'vector': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]}
     )
     def test_state_preparation(self, vector):
-        vector = numpy.asarray(vector)
-        vector = (1 / numpy.linalg.norm(vector)) * vector
+        self.check_add_vector(vector)
+
+        vector = np.asarray(vector)
+        vector = (1 / np.linalg.norm(vector)) * vector
         self.execute_test(list(vector))
+
+    def check_add_vector(self, vector):
+        unit_vector = np.asarray(vector)
+        l2_norm = np.linalg.norm(unit_vector)
+        unit_vector = unit_vector / l2_norm
+
+        labels = [i for i, v in enumerate(unit_vector) if abs(v) > 1e-6]
+        db = FFQramDb()
+        add_vector(db, vector)
+
+        check_labels = [int.from_bytes(e.label, byteorder='big') for e in db]
+
+        self.assertListEqual(labels, check_labels)
 
 
 if __name__ == '__main__':

--- a/tests/test_FlipFlopQuantumRam.py
+++ b/tests/test_FlipFlopQuantumRam.py
@@ -15,7 +15,7 @@
 import unittest
 from typing import List
 
-import numpy
+import numpy as np
 import qiskit
 from ddt import ddt, data as test_data, unpack
 from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
@@ -29,7 +29,7 @@ from dc_qiskit_algorithms.FlipFlopQuantumRam import FFQramDb, add_vector
 class FlipFlopQuantumRamnStatePrepTests(unittest.TestCase):
 
     def execute_test(self, vector: List[float]):
-        probability_vector = [numpy.absolute(e)**2 for e in vector]
+        probability_vector = [np.absolute(e)**2 for e in vector]
         print("Input Vector (state) & its measurement probability:")
         print(["{0:.3f}".format(e) for e in vector])
         print(["{0:.3f}".format(e) for e in probability_vector])
@@ -58,8 +58,8 @@ class FlipFlopQuantumRamnStatePrepTests(unittest.TestCase):
         print("Full simulated state vector (n+1!)")
         print(["{0:.2f}".format(e) for e in result_state_vector])
 
-        correct_branch_state = numpy.asarray(result_state_vector)[8:]
-        correct_branch_state = correct_branch_state / numpy.linalg.norm(correct_branch_state)
+        correct_branch_state = np.asarray(result_state_vector)[8:]
+        correct_branch_state = correct_branch_state / np.linalg.norm(correct_branch_state)
 
         print("State vector on the correct (1) branch:")
         print(["{0:.2f}".format(e) for e in correct_branch_state])


### PR DESCRIPTION
This is a serious fix to the FFQRAM state preparation when using integer data. We were using `bitarray`lib to handle bit strings and conversion. This had a behavior that we did not want. Python >=3.5 code has good routines that behave as we need. This has been changed, so that the method works the same as before but we had to deprecate the following two functions:
- dc_qiskit_algorithms.FlipFlopQuantumRam.FFQramDb.add_entry_int
- dc_qiskit_algorithms.FlipFlopQuantumRam.FFQramEntry._count_set_bits

We don't expect that this will affect many customers. The logic replacing the first function is now included in the function 
- dc_qiskit_algorithms.FlipFlopQuantumRam.add_vector

where it actually makes sense.